### PR TITLE
ST13-3843:Create_Target_Group_EC2_Mayowa_Babatola_v1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ crash.log
 *.log
 
 userdata.sh
+assume-role2.sh
+.terraform.lock.hcl

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,4 +10,7 @@ output "private_subnet_ids" {
   value = [for subnet in aws_subnet.private_subnets: subnet.id]
 }
 
-
+output "target_group_arn" {
+  description = "The ARN of the CliXX Web Application Target Group"
+  value       = aws_lb_target_group.clixx_web_tg.arn
+}

--- a/vars.tf
+++ b/vars.tf
@@ -139,3 +139,36 @@ variable "aws_session_token" {
 }
 
 
+variable "target_group_name" {
+  description = "Name of the Target Group for the CliXX Web Application"
+  type        = string
+  default     = "cliXX-web-tg"
+}
+
+variable "target_group_port" {
+  description = "The port on which the target group will listen"
+  type        = number
+  default     = 80
+}
+
+variable "target_group_protocol" {
+  description = "The protocol used by the target group"
+  type        = string
+  default     = "HTTP"
+}
+
+variable "az_mapping" {
+  description = "Mapping of subnets to Availability Zones"
+  type        = map(string)
+  default = {
+    "10.0.1.0/24" = "us-east-1a"
+    "10.0.2.0/24" = "us-east-1b"
+    "10.0.3.0/24" = "us-east-1c"
+  }
+}
+
+variable "default_az" {
+  description = "Default Availability Zone if mapping is not found"
+  type        = string
+  default     = "us-east-1a"
+}


### PR DESCRIPTION
Link to story https://stack-jira.atlassian.net/browse/ST13-3843

This pull request introduces the following changes:
Created a Target Group for EC2 instances.

Provisioned an Application Load Balancer (ALB) with the following features:
   - Configured for HTTP (port 80) and HTTPS (port 443).
   - Secure listener configuration (with optional SSL support).
   - Automatically attached to public subnets in multiple availability zones (AZs).
   - Integrated Health Checks to monitor target instance health.
   - Enhanced Security: Configured the ALB with appropriate security group settings.
  - Dynamic Configuration: Utilized Terraform list comprehension for dynamic subnet management.

