### PR TITLE
ST13-4304: CLIXX_DEPLOYMENT_TERRAFORM: Import_SSL_Cert_Mayowa_Babatol…

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -86,3 +86,10 @@ data "aws_subnets" "public_subnets" {
     values = ["Public"] # Ensure the Type tag is set in the subnet creation
   }
 }
+
+# Data source for existing ACM certificate
+data "aws_acm_certificate" "clixx_cert" {
+  domain      = "*.stack-mayowa.com"  # The domain name on the certificate
+  statuses    = ["ISSUED"]                # Only get certificates that are active
+  most_recent = true                     # In case there are multiple matching certificates
+}

--- a/main.tf
+++ b/main.tf
@@ -163,6 +163,20 @@ resource "aws_lb_listener" "clixx_listener" {
 }
 
 
+# HTTPS Listener for the load balancer using existing certificate
+resource "aws_lb_listener" "clixx_listener_https" {
+  load_balancer_arn = aws_lb.clixx_lb.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = data.aws_acm_certificate.clixx_cert.arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.clixx_web_tg.arn
+  }
+}
+
 # Target Group
 resource "aws_lb_target_group" "clixx_web_tg" {
   name        = var.target_group_name


### PR DESCRIPTION
Link to Jira story: https://stack-jira.atlassian.net/browse/ST13-4304

- Automated SSL Certificate Import: Easily import existing SSL certificates (PEM-encoded) into AWS ACM using Terraform.
- Efficient Management: Automatically clean up certificates when the Terraform stack is destroyed.
