### PR TITLE
ST13-4306: Restore_RDS_Instance_Mayowa_Babatola_v1.9

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -59,6 +59,9 @@ locals {
 
   # Account ID for use in other resources
   account_id = data.aws_caller_identity.current.account_id
+
+  # Convert environment to lowercase and replace spaces with hyphens for resource naming
+  env_name_normalized = lower(replace(var.environment, " ", "-"))
 }
 
 # ==========================================
@@ -89,7 +92,14 @@ data "aws_subnets" "public_subnets" {
 
 # Data source for existing ACM certificate
 data "aws_acm_certificate" "clixx_cert" {
-  domain      = "*.stack-mayowa.com"  # The domain name on the certificate
-  statuses    = ["ISSUED"]                # Only get certificates that are active
-  most_recent = true                     # In case there are multiple matching certificates
+  domain      = "*.stack-mayowa.com" # The domain name on the certificate
+  statuses    = ["ISSUED"]           # Only get certificates that are active
+  most_recent = true                 # In case there are multiple matching certificates
+}
+
+
+# Data source to reference an existing AWS RDS snapshot
+data "aws_db_snapshot" "clixx_snapshot" {
+  db_snapshot_identifier = var.snapshot_identifier
+  most_recent            = true # Optional: set to true to use the most recent snapshot
 }

--- a/database.tf
+++ b/database.tf
@@ -1,0 +1,110 @@
+# ==========================================
+# RDS Database Configuration for CliXX
+# ==========================================
+
+
+# DB Parameter Group - for MySQL 8.0.35 as per snapshot
+resource "aws_db_parameter_group" "clixx_db_params" {
+  name   = "clixx-db-params-${local.env_name_normalized}"
+  family = "mysql8.0" # Matches the snapshot MySQL version
+
+  parameter {
+    name  = "max_connections"
+    value = var.environment == "production" ? "1000" : "100"
+  }
+
+  parameter {
+    name  = "character_set_server"
+    value = "utf8mb4"
+  }
+
+  tags = {
+    Name        = "CliXX DB Parameters"
+    Environment = var.environment
+  }
+}
+
+# DB Subnet Group needed for RDS
+resource "aws_db_subnet_group" "clixx_db_subnet_group" {
+  name        = "clixx-db-subnet-group-${local.env_name_normalized}" # Fixed the name here
+  description = "DB subnet group for CliXX application"
+  subnet_ids  = [for subnet in aws_subnet.private_subnets : subnet.id]
+
+  tags = {
+    Name        = "CliXX DB Subnet Group"
+    Environment = var.environment
+  }
+}
+
+# AWS RDS instance restored from snapshot
+resource "aws_db_instance" "clixx_db_from_snapshot" {
+  identifier          = "clixx-db-${local.env_name_normalized}"
+  snapshot_identifier = data.aws_db_snapshot.clixx_snapshot.id
+
+  # Instance specifications
+  instance_class = var.db_instance_class
+
+  # Network configuration
+  db_subnet_group_name   = aws_db_subnet_group.clixx_db_subnet_group.name
+  vpc_security_group_ids = [aws_security_group.db_sg.id]
+  publicly_accessible    = false
+
+  # Multi-AZ deployment for high availability in production
+  multi_az = var.environment == "development" ? true : false
+
+  # Apply changes immediately or during maintenance window
+  apply_immediately = var.environment != "development"
+
+  # Backup configuration
+  backup_retention_period = var.environment == "development" ? 7 : 1
+  backup_window           = "03:00-04:00"
+  maintenance_window      = "Mon:04:30-Mon:05:30"
+
+  # Parameter and option groups
+  parameter_group_name = aws_db_parameter_group.clixx_db_params.name
+
+  # Final snapshot configuration
+  skip_final_snapshot       = var.environment != "development"
+  final_snapshot_identifier = var.environment == "development" ? "clixx-db-final-${formatdate("YYYY-MM-DD", timestamp())}" : null
+
+  # Performance insights
+  performance_insights_enabled          = true
+  performance_insights_retention_period = var.environment == "development" ? 7 : 0
+
+  # Deletion protection
+  deletion_protection = var.environment == "development"
+
+  # Engine settings from the snapshot
+  engine         = "mysql"
+  engine_version = "8.0.35"
+
+  # Port settings matching the snapshot
+  port = 3306
+
+  # Tags
+  tags = {
+    Name        = "CliXX-Database"
+    Environment = var.environment
+    Application = "CliXX Web App"
+    OwnerEmail  = "mayowa.k.babatola@gmail.com"
+    StackTeam   = "Stackcloud13"
+    RestoreDate = formatdate("YYYY-MM-DD", timestamp())
+  }
+}
+
+# Resource to store DB endpoint in SSM Parameter Store
+resource "aws_ssm_parameter" "db_endpoint" {
+  name        = "/clixx/${local.env_name_normalized}/db/endpoint"
+  description = "CliXX Database Endpoint"
+  type        = "String"
+  value       = aws_db_instance.clixx_db_from_snapshot.endpoint
+
+  tags = {
+    Environment = var.environment
+    Application = "CliXX Web App"
+  }
+}
+
+
+
+

--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,7 @@ resource "aws_launch_template" "clixx_web_app" {
   network_interfaces {
     associate_public_ip_address = true # Auto-assign Public IP (for public subnet)
     #subnet_id                   = values(aws_subnet.public_subnets)[0].id
-    security_groups             = [aws_security_group.public_sg.id] # Existing SG
+    security_groups = [aws_security_group.public_sg.id] # Existing SG
   }
 
   iam_instance_profile {
@@ -63,8 +63,11 @@ resource "aws_launch_template" "clixx_web_app" {
   # Secure Startup Configuration (User Data)
   user_data = base64encode(
     templatefile("${path.module}/userdata.sh", {
-      EFS_ID      = aws_efs_file_system.clixx_efs.dns_name #EFS_ID
-      MOUNT_POINT = "/var/www/html"
+      EFS_ID            = aws_efs_file_system.clixx_efs.dns_name #EFS_ID
+      MOUNT_POINT       = "/var/www/html"
+      ENVIRONMENT       = var.environment
+      ENVIRONMENT_LOWER = local.env_name_normalized
+      REGION            = var.aws_region
     })
   )
 
@@ -101,7 +104,7 @@ resource "aws_launch_template" "clixx_web_app" {
       delete_on_termination = true
     }
   }
-  
+
   block_device_mappings {
     device_name = "/dev/sdc"
     ebs {
@@ -110,7 +113,7 @@ resource "aws_launch_template" "clixx_web_app" {
       delete_on_termination = true
     }
   }
-  
+
   block_device_mappings {
     device_name = "/dev/sdd"
     ebs {
@@ -119,7 +122,7 @@ resource "aws_launch_template" "clixx_web_app" {
       delete_on_termination = true
     }
   }
-  
+
   block_device_mappings {
     device_name = "/dev/sde"
     ebs {
@@ -233,7 +236,6 @@ resource "aws_autoscaling_group" "clixx_asg" {
 }
 
 
-
 # ROUTE 53 
 
 # Reference the hosted zone for stack-mayowa.com
@@ -247,7 +249,7 @@ resource "aws_route53_record" "clixx" {
   zone_id = data.aws_route53_zone.selected.zone_id
   name    = "clixx.stack-mayowa.com"
   type    = "A"
-  
+
   alias {
     name                   = aws_lb.clixx_lb.dns_name
     zone_id                = aws_lb.clixx_lb.zone_id
@@ -263,7 +265,6 @@ resource "aws_route53_record" "www_clixx" {
   ttl     = "300"
   records = ["clixx.stack-mayowa.com"]
 }
-
 
 
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -62,3 +62,23 @@ output "efs_id" {
 }
 
 
+# Database-related outputs
+output "rds_endpoint" {
+  description = "The connection endpoint for the RDS database"
+  value       = aws_db_instance.clixx_db_from_snapshot.endpoint
+}
+
+output "rds_port" {
+  description = "The port on which the RDS database accepts connections"
+  value       = aws_db_instance.clixx_db_from_snapshot.port
+}
+
+output "rds_name" {
+  description = "The name of the RDS database"
+  value       = aws_db_instance.clixx_db_from_snapshot.identifier
+}
+
+output "ssm_db_endpoint_parameter" {
+  description = "The SSM parameter name that contains the RDS endpoint"
+  value       = aws_ssm_parameter.db_endpoint.name
+}

--- a/vars.tf
+++ b/vars.tf
@@ -193,3 +193,23 @@ variable "mount_point" {
   type        = string
   default     = "/var/www/html"
 }
+
+
+# RDS Snapshot Variables
+variable "rds_snapshot_id" {
+  description = "The ID of the RDS snapshot to create the database from"
+  type        = string
+  default     = "clixx-production-snapshot-20240517" # Your specific snapshot ID
+}
+
+variable "db_instance_class" {
+  description = "The instance class for the RDS instance"
+  type        = string
+  default     = "db.m6g.large"
+}
+
+variable "snapshot_identifier" {
+  description = "The identifier of the DB snapshot to restore from"
+  type        = string
+  default     = "clixxdbsnapshot" # Based on your snapshot name from the image
+}


### PR DESCRIPTION
This is the link to the Jira story: https://stack-jira.atlassian.net/browse/ST13-4306

This pull request introduces the feature to restore an Amazon RDS instance from a snapshot. The implementation is designed to streamline the RDS recovery process, ensuring data integrity and availability in the event of a failure or data loss.

- Implemented the logic to restore the RDS instance from a specified snapshot.
- Added Terraform configurations for automated RDS instance creation using the specified snapshot.
- Updated main.tf and outputs.tf for improved resource management and output clarity.
- Included detailed comments for better code readability.